### PR TITLE
Add file search

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -197,6 +197,13 @@ jobs:
         cmake -S kservice -B kservice/build -GNinja 
         cmake --build kservice/build --parallel
         sudo cmake --install kservice/build
+    
+    - name: Build kauth
+      run: |
+        git clone https://github.com/KDE/kauth.git
+        cmake -S kauth -B kauth/build -GNinja 
+        cmake --build kauth/build --parallel
+        sudo cmake --install kauth/build
 
     - name: Build kio
       run: |

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -136,6 +136,41 @@ jobs:
         cmake -S kiconthemes -B kiconthemes/build -GNinja 
         cmake --build kiconthemes/build --parallel
         sudo cmake --install kiconthemes/build
+    
+    - name: Build kdbusaddons
+      run: |
+        git clone https://github.com/KDE/kdbusaddons.git
+        cmake -S kdbusaddons -B kdbusaddons/build -GNinja 
+        cmake --build kdbusaddons/build --parallel
+        sudo cmake --install kdbusaddons/build
+    
+    - name: Build kidletime
+      run: |
+        git clone https://github.com/KDE/kidletime.git
+        cmake -S kidletime -B kidletime/build -GNinja 
+        cmake --build kidletime/build --parallel
+        sudo cmake --install kidletime/build
+    
+    - name: Build solid
+      run: |
+        git clone https://github.com/KDE/solid.git
+        cmake -S solid -B solid/build -GNinja 
+        cmake --build solid/build --parallel
+        sudo cmake --install solid/build
+
+    - name: Build kfilemetadata
+      run: |
+        git clone https://github.com/KDE/kfilemetadata.git
+        cmake -S kfilemetadata -B kfilemetadata/build -GNinja 
+        cmake --build kfilemetadata/build --parallel
+        sudo cmake --install kfilemetadata/build
+
+    - name: Build kcrash
+      run: |
+        git clone https://github.com/KDE/kcrash.git
+        cmake -S kcrash -B kcrash/build -GNinja 
+        cmake --build kcrash/build --parallel
+        sudo cmake --install kcrash/build
 
     - name: Remove specific lines from CMakeLists.txt
       run: |

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -183,6 +183,13 @@ jobs:
         cmake -S kcrash -B kcrash/build -GNinja 
         cmake --build kcrash/build --parallel
         sudo cmake --install kcrash/build
+
+    - name: Build kio
+      run: |
+        git clone https://github.com/KDE/kio.git
+        cmake -S kio -B kio/build -GNinja
+        cmake --build kio/build --parallel
+        sudo cmake --install kio/build
     
     - name: Build baloo
       run: |

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -18,7 +18,7 @@ jobs:
         sudo apt update
         sudo apt install build-essential cmake ninja-build meson gettext gperf *wayland* libsdl2-dev clang-format libxcb-sync-dev flex bison udev ffmpeg libattr1-dev libx11* --fix-missing
         sudo apt remove wayland-protocols
-        
+
     - name: Install CUDA
       uses: Jimver/cuda-toolkit@v0.2.17
       id: cuda-toolkit
@@ -145,12 +145,16 @@ jobs:
         cmake --build kdbusaddons/build --parallel
         sudo cmake --install kdbusaddons/build
     
-    - name: Build wayland-protocols
+    - name: Clone wayland-protocols
       run: |
         git clone https://gitlab.freedesktop.org/wayland/wayland-protocols.git
+        
+    - name: Build wayland-protocols
+      working-directory: wayland-protocols
+      run: |
         meson setup build
         meson compile -C build
-        sudo meson install -C builddir
+        sudo meson install -C build
 
     - name: Build kidletime
       run: |
@@ -179,6 +183,13 @@ jobs:
         cmake -S kcrash -B kcrash/build -GNinja 
         cmake --build kcrash/build --parallel
         sudo cmake --install kcrash/build
+    
+    - name: Build baloo
+      run: |
+        git clone https://github.com/KDE/baloo.git
+        cmake -S baloo -B baloo/build -GNinja 
+        cmake --build baloo/build --parallel
+        sudo cmake --install baloo/build
 
     - name: Remove specific lines from CMakeLists.txt
       run: |

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt install build-essential cmake ninja-build meson gettext gperf *wayland* libsdl2-dev clang-format libxcb-sync-dev flex bison udev ffmpeg libattr1-dev libx11* --fix-missing
+        sudo apt install build-essential cmake ninja-build meson gettext gperf *wayland* libsdl2-dev clang-format libxcb-sync-dev flex bison udev libxslt1-dev libxml2-dev docbook-xsl docbook-xml xsltproc ffmpeg libattr1-dev libx11* --fix-missing
         sudo apt remove wayland-protocols
 
     - name: Install CUDA
@@ -184,10 +184,24 @@ jobs:
         cmake --build kcrash/build --parallel
         sudo cmake --install kcrash/build
 
+    - name: Build kdoctools
+      run: |
+        git clone https://github.com/KDE/kdoctools.git
+        cmake -S kdoctools -B kdoctools/build -GNinja 
+        cmake --build kdoctools/build --parallel
+        sudo cmake --install kdoctools/build
+
+    - name: Build kservice
+      run: |
+        git clone https://github.com/KDE/kservice.git
+        cmake -S kservice -B kservice/build -GNinja 
+        cmake --build kservice/build --parallel
+        sudo cmake --install kservice/build
+
     - name: Build kio
       run: |
         git clone https://github.com/KDE/kio.git
-        cmake -S kio -B kio/build -GNinja
+        cmake -S kio -B kio/build -GNinja -DKIOCORE_ONLY=ON
         cmake --build kio/build --parallel
         sudo cmake --install kio/build
     

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -152,7 +152,7 @@ jobs:
     - name: Build wayland-protocols
       working-directory: wayland-protocols
       run: |
-        meson setup build
+        meson setup build -Dtests=false
         meson compile -C build
         sudo meson install -C build
 

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt install build-essential cmake ninja-build gettext gperf *wayland* libsdl2-dev clang-format --fix-missing
+        sudo apt install build-essential cmake ninja-build gettext gperf *wayland* libsdl2-dev clang-format libxcb-sync-dev flex bison udev ffmpeg libattr1-dev --fix-missing
 
     - name: Install CUDA
       uses: Jimver/cuda-toolkit@v0.2.17

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt install build-essential cmake ninja-build gettext gperf *wayland* libsdl2-dev clang-format libxcb-sync-dev flex bison udev ffmpeg libattr1-dev --fix-missing
+        sudo apt install build-essential cmake ninja-build gettext gperf *wayland* libsdl2-dev clang-format libxcb-sync-dev flex bison udev ffmpeg libattr1-dev libx11* --fix-missing
 
     - name: Install CUDA
       uses: Jimver/cuda-toolkit@v0.2.17

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -16,8 +16,9 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt install build-essential cmake ninja-build gettext gperf *wayland* libsdl2-dev clang-format libxcb-sync-dev flex bison udev ffmpeg libattr1-dev libx11* --fix-missing
-
+        sudo apt install build-essential cmake ninja-build meson gettext gperf *wayland* libsdl2-dev clang-format libxcb-sync-dev flex bison udev ffmpeg libattr1-dev libx11* --fix-missing
+        sudo apt remove wayland-protocols
+        
     - name: Install CUDA
       uses: Jimver/cuda-toolkit@v0.2.17
       id: cuda-toolkit
@@ -144,6 +145,13 @@ jobs:
         cmake --build kdbusaddons/build --parallel
         sudo cmake --install kdbusaddons/build
     
+    - name: Build wayland-protocols
+      run: |
+        git clone https://gitlab.freedesktop.org/wayland/wayland-protocols.git
+        meson setup build
+        meson compile -C build
+        sudo meson install -C builddir
+
     - name: Build kidletime
       run: |
         git clone https://github.com/KDE/kidletime.git

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -13,149 +13,149 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Install Dependencies
-      run: |
-        sudo apt update
-        sudo apt install build-essential cmake ninja-build gettext gperf *wayland* libsdl2-dev clang-format --fix-missing
+    # - name: Install Dependencies
+    #   run: |
+    #     sudo apt update
+    #     sudo apt install build-essential cmake ninja-build gettext gperf *wayland* libsdl2-dev clang-format --fix-missing
 
-    - name: Install CUDA
-      uses: Jimver/cuda-toolkit@v0.2.17
-      id: cuda-toolkit
+    # - name: Install CUDA
+    #   uses: Jimver/cuda-toolkit@v0.2.17
+    #   id: cuda-toolkit
 
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        aqtversion: '==3.1.*'
-        version: '6.7.*'
-        host: 'linux'
-        target: 'desktop'
-        arch: 'linux_gcc_64'
-        modules: 'qtshadertools qtwaylandcompositor'
+    # - name: Install Qt
+    #   uses: jurplel/install-qt-action@v3
+    #   with:
+    #     aqtversion: '==3.1.*'
+    #     version: '6.7.*'
+    #     host: 'linux'
+    #     target: 'desktop'
+    #     arch: 'linux_gcc_64'
+    #     modules: 'qtshadertools qtwaylandcompositor'
 
-    - name: Build ECM
-      run: |
-        git clone https://github.com/KDE/extra-cmake-modules.git
-        cmake -S extra-cmake-modules -B extra-cmake-modules/build -GNinja 
-        cmake --build extra-cmake-modules/build --parallel
-        sudo cmake --install extra-cmake-modules/build
+    # - name: Build ECM
+    #   run: |
+    #     git clone https://github.com/KDE/extra-cmake-modules.git
+    #     cmake -S extra-cmake-modules -B extra-cmake-modules/build -GNinja 
+    #     cmake --build extra-cmake-modules/build --parallel
+    #     sudo cmake --install extra-cmake-modules/build
 
-    - name: Build kirigami
-      run: |
-        git clone https://github.com/KDE/kirigami.git
-        cmake -S kirigami -B kirigami/build -GNinja 
-        cmake --build kirigami/build --parallel
-        sudo cmake --install kirigami/build
+    # - name: Build kirigami
+    #   run: |
+    #     git clone https://github.com/KDE/kirigami.git
+    #     cmake -S kirigami -B kirigami/build -GNinja 
+    #     cmake --build kirigami/build --parallel
+    #     sudo cmake --install kirigami/build
 
-    - name: Build kcoreaddons
-      run: |
-        git clone https://github.com/KDE/kcoreaddons.git
-        cmake -S kcoreaddons -B kcoreaddons/build -GNinja 
-        cmake --build kcoreaddons/build --parallel
-        sudo cmake --install kcoreaddons/build
+    # - name: Build kcoreaddons
+    #   run: |
+    #     git clone https://github.com/KDE/kcoreaddons.git
+    #     cmake -S kcoreaddons -B kcoreaddons/build -GNinja 
+    #     cmake --build kcoreaddons/build --parallel
+    #     sudo cmake --install kcoreaddons/build
 
-    - name: Build ki18n
-      run: |
-        git clone https://github.com/KDE/ki18n.git
-        cmake -S ki18n -B ki18n/build -GNinja 
-        cmake --build ki18n/build --parallel
-        sudo cmake --install ki18n/build
+    # - name: Build ki18n
+    #   run: |
+    #     git clone https://github.com/KDE/ki18n.git
+    #     cmake -S ki18n -B ki18n/build -GNinja 
+    #     cmake --build ki18n/build --parallel
+    #     sudo cmake --install ki18n/build
 
-    - name: Build kconfig
-      run: |
-        git clone https://github.com/KDE/kconfig.git
-        cmake -S kconfig -B kconfig/build -GNinja 
-        cmake --build kconfig/build --parallel
-        sudo cmake --install kconfig/build
+    # - name: Build kconfig
+    #   run: |
+    #     git clone https://github.com/KDE/kconfig.git
+    #     cmake -S kconfig -B kconfig/build -GNinja 
+    #     cmake --build kconfig/build --parallel
+    #     sudo cmake --install kconfig/build
 
-    - name: Build qqc2-desktop-style
-      run: |
-        git clone https://github.com/KDE/qqc2-desktop-style.git
-        cmake -S qqc2-desktop-style -B qqc2-desktop-style/build -GNinja 
-        cmake --build qqc2-desktop-style/build --parallel
-        sudo cmake --install qqc2-desktop-style/build
+    # - name: Build qqc2-desktop-style
+    #   run: |
+    #     git clone https://github.com/KDE/qqc2-desktop-style.git
+    #     cmake -S qqc2-desktop-style -B qqc2-desktop-style/build -GNinja 
+    #     cmake --build qqc2-desktop-style/build --parallel
+    #     sudo cmake --install qqc2-desktop-style/build
 
-    - name: Build karchive
-      run: |
-        git clone https://github.com/KDE/karchive.git
-        cmake -S karchive -B karchive/build -GNinja 
-        cmake --build karchive/build --parallel
-        sudo cmake --install karchive/build
+    # - name: Build karchive
+    #   run: |
+    #     git clone https://github.com/KDE/karchive.git
+    #     cmake -S karchive -B karchive/build -GNinja 
+    #     cmake --build karchive/build --parallel
+    #     sudo cmake --install karchive/build
 
-    - name: Build kcodecs
-      run: |
-        git clone https://github.com/KDE/kcodecs.git
-        cmake -S kcodecs -B kcodecs/build -GNinja 
-        cmake --build kcodecs/build --parallel
-        sudo cmake --install kcodecs/build
+    # - name: Build kcodecs
+    #   run: |
+    #     git clone https://github.com/KDE/kcodecs.git
+    #     cmake -S kcodecs -B kcodecs/build -GNinja 
+    #     cmake --build kcodecs/build --parallel
+    #     sudo cmake --install kcodecs/build
 
-    - name: Build plasma-wayland-protocols
-      run: |
-        git clone https://github.com/KDE/plasma-wayland-protocols.git
-        cmake -S plasma-wayland-protocols -B plasma-wayland-protocols/build -GNinja 
-        cmake --build plasma-wayland-protocols/build --parallel
-        sudo cmake --install plasma-wayland-protocols/build
+    # - name: Build plasma-wayland-protocols
+    #   run: |
+    #     git clone https://github.com/KDE/plasma-wayland-protocols.git
+    #     cmake -S plasma-wayland-protocols -B plasma-wayland-protocols/build -GNinja 
+    #     cmake --build plasma-wayland-protocols/build --parallel
+    #     sudo cmake --install plasma-wayland-protocols/build
     
-    - name: Build kguiaddons
-      run: |
-        git clone https://github.com/KDE/kguiaddons.git
-        cmake -S kguiaddons -B kguiaddons/build -GNinja 
-        cmake --build kguiaddons/build --parallel
-        sudo cmake --install kguiaddons/build
+    # - name: Build kguiaddons
+    #   run: |
+    #     git clone https://github.com/KDE/kguiaddons.git
+    #     cmake -S kguiaddons -B kguiaddons/build -GNinja 
+    #     cmake --build kguiaddons/build --parallel
+    #     sudo cmake --install kguiaddons/build
     
-    - name: Build kwidgetsaddons
-      run: |
-        git clone https://github.com/KDE/kwidgetsaddons.git
-        cmake -S kwidgetsaddons -B kwidgetsaddons/build -GNinja 
-        cmake --build kwidgetsaddons/build --parallel
-        sudo cmake --install kwidgetsaddons/build
+    # - name: Build kwidgetsaddons
+    #   run: |
+    #     git clone https://github.com/KDE/kwidgetsaddons.git
+    #     cmake -S kwidgetsaddons -B kwidgetsaddons/build -GNinja 
+    #     cmake --build kwidgetsaddons/build --parallel
+    #     sudo cmake --install kwidgetsaddons/build
     
-    - name: Build kcolorscheme
-      run: |
-        git clone https://github.com/KDE/kcolorscheme.git
-        cmake -S kcolorscheme -B kcolorscheme/build -GNinja 
-        cmake --build kcolorscheme/build --parallel
-        sudo cmake --install kcolorscheme/build
+    # - name: Build kcolorscheme
+    #   run: |
+    #     git clone https://github.com/KDE/kcolorscheme.git
+    #     cmake -S kcolorscheme -B kcolorscheme/build -GNinja 
+    #     cmake --build kcolorscheme/build --parallel
+    #     sudo cmake --install kcolorscheme/build
     
-    - name: Build kconfigwidgets
-      run: |
-        git clone https://github.com/KDE/kconfigwidgets.git
-        cmake -S kconfigwidgets -B kconfigwidgets/build -GNinja 
-        cmake --build kconfigwidgets/build --parallel
-        sudo cmake --install kconfigwidgets/build
+    # - name: Build kconfigwidgets
+    #   run: |
+    #     git clone https://github.com/KDE/kconfigwidgets.git
+    #     cmake -S kconfigwidgets -B kconfigwidgets/build -GNinja 
+    #     cmake --build kconfigwidgets/build --parallel
+    #     sudo cmake --install kconfigwidgets/build
     
-    - name: Build breeze-icons
-      run: |
-        git clone https://github.com/KDE/breeze-icons.git
-        cmake -S breeze-icons -B breeze-icons/build -GNinja 
-        cmake --build breeze-icons/build --parallel
-        sudo cmake --install breeze-icons/build
+    # - name: Build breeze-icons
+    #   run: |
+    #     git clone https://github.com/KDE/breeze-icons.git
+    #     cmake -S breeze-icons -B breeze-icons/build -GNinja 
+    #     cmake --build breeze-icons/build --parallel
+    #     sudo cmake --install breeze-icons/build
     
-    - name: Build kiconstheme
-      run: |
-        git clone https://github.com/KDE/kiconthemes.git
-        cmake -S kiconthemes -B kiconthemes/build -GNinja 
-        cmake --build kiconthemes/build --parallel
-        sudo cmake --install kiconthemes/build
+    # - name: Build kiconstheme
+    #   run: |
+    #     git clone https://github.com/KDE/kiconthemes.git
+    #     cmake -S kiconthemes -B kiconthemes/build -GNinja 
+    #     cmake --build kiconthemes/build --parallel
+    #     sudo cmake --install kiconthemes/build
 
-    - name: Remove specific lines from CMakeLists.txt
-      run: |
-        sed -i '/include(KDEClangFormat)/d' CMakeLists.txt
-        sed -i '/file(GLOB_RECURSE ALL_CLANG_FORMAT_SOURCE_FILES \*.cpp \*.h \*.hpp \*.c)/d' CMakeLists.txt
-        sed -i '/kde_clang_format(${ALL_CLANG_FORMAT_SOURCE_FILES})/d' CMakeLists.txt
+    # - name: Remove specific lines from CMakeLists.txt
+    #   run: |
+    #     sed -i '/include(KDEClangFormat)/d' CMakeLists.txt
+    #     sed -i '/file(GLOB_RECURSE ALL_CLANG_FORMAT_SOURCE_FILES \*.cpp \*.h \*.hpp \*.c)/d' CMakeLists.txt
+    #     sed -i '/kde_clang_format(${ALL_CLANG_FORMAT_SOURCE_FILES})/d' CMakeLists.txt
 
     - name: Configure Repo
       run: |
         git submodule init
         git submodule update
 
-    - name: Configure CMake
-      run: cmake -B build -GNinja
+    # - name: Configure CMake
+    #   run: cmake -B build -GNinja
 
-    - name: Build
-      run: cmake --build build --parallel
+    # - name: Build
+    #   run: cmake --build build --parallel
 
-    - name: Install
-      run: sudo cmake --install build/
+    # - name: Install
+    #   run: sudo cmake --install build/
     
     # - name: Test
     #     working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(src/ui)
 add_subdirectory(src/common)
 add_subdirectory(src/model_backend)
 add_subdirectory(src/screenshot)
+add_subdirectory(src/file_search)
 
 include(KDEClangFormat)
 file(GLOB_RECURSE ALL_CLANG_FORMAT_SOURCE_FILES *.cpp *.h *.hpp *.c)

--- a/docs/BuildInstructions.md
+++ b/docs/BuildInstructions.md
@@ -19,18 +19,18 @@ Run the below command relevant to your distribution.
 
 ### Arch:
 ```bash
-sudo pacman -S base-devel extra-cmake-modules cmake kirigami ki18n kcoreaddons breeze kiconthemes qt6-base qt6-declarative qqc2-desktop-style sdl2
+sudo pacman -S base-devel extra-cmake-modules cmake kirigami ki18n kcoreaddons breeze kiconthemes qt6-base qt6-declarative qqc2-desktop-style sdl2 baloo
 ```
 
 ### OpenSUSE:
 ```bash
-sudo zypper install cmake kf6-extra-cmake-modules kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel kf6-kiconthemes-devel qt6-base-devel qt6-declarative-devel qt6-quickcontrols2-devel kf6-qqc2-desktop-style SDL2-devel
+sudo zypper install cmake kf6-extra-cmake-modules kf6-kirigami-devel kf6-ki18n-devel kf6-kcoreaddons-devel kf6-kiconthemes-devel qt6-base-devel qt6-declarative-devel qt6-quickcontrols2-devel kf6-qqc2-desktop-style SDL2-devel kf6-baloo-devel
 ```
 
 ### Fedora:
 ```bash
 sudo dnf groupinstall "Development Tools" "Development Libraries"
-sudo dnf install cmake extra-cmake-modules kf6-kirigami2-devel kf6-ki18n-devel kf6-kcoreaddons-devel kf6-kiconthemes-devel qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qtquickcontrols2-devel kf6-qqc2-desktop-style SDL2-devel
+sudo dnf install cmake extra-cmake-modules kf6-kirigami2-devel kf6-ki18n-devel kf6-kcoreaddons-devel kf6-kiconthemes-devel qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qtquickcontrols2-devel kf6-qqc2-desktop-style SDL2-devel kf6-baloo-devel
 ```
 
 ### Ubuntu: (DOES NOT WORK)

--- a/src/file_search/CMakeLists.txt
+++ b/src/file_search/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_sources(koolintelligence PRIVATE file_search.cpp)
+target_include_directories(koolintelligence PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/file_search/file_search.cpp
+++ b/src/file_search/file_search.cpp
@@ -5,11 +5,12 @@ Reference for how this works and where it is taken from:
 https://invent.kde.org/frameworks/baloo/-/blob/master/src/tools/baloosearch/main.cpp
 https://invent.kde.org/frameworks/baloo/-/blob/master/src/lib/query.h
 
-It will only return file paths for now. 
-However the results are also based on the file contents as indexed by baloo/krunner. 
+It will only return file paths for now.
+However the results are also based on the file contents as indexed by baloo/krunner.
 Note that this is KDE specific.
  */
-std::vector<std::string> fileSearchKDE(const std::string& searchTerm){
+std::vector<std::string> fileSearchKDE(const std::string &searchTerm)
+{
     const uint numberOfResults = 10;
     Baloo::Query query;
     // query.addType(typeStr);

--- a/src/file_search/file_search.cpp
+++ b/src/file_search/file_search.cpp
@@ -1,0 +1,27 @@
+#include "file_search.hpp"
+#include <baloo/query.h>
+/**
+Reference for how this works and where it is taken from:
+https://invent.kde.org/frameworks/baloo/-/blob/master/src/tools/baloosearch/main.cpp
+https://invent.kde.org/frameworks/baloo/-/blob/master/src/lib/query.h
+
+It will only return file paths for now. 
+However the results are also based on the file contents as indexed by baloo/krunner. 
+Note that this is KDE specific.
+ */
+std::vector<std::string> fileSearchKDE(const std::string& searchTerm){
+    const uint numberOfResults = 10;
+    Baloo::Query query;
+    // query.addType(typeStr);
+    query.setSearchString(QString().fromStdString(searchTerm));
+    query.setLimit(numberOfResults);
+    query.setSortingOption(Baloo::Query::SortAuto);
+    // query.setIncludeFolder(canonicalPath);
+    Baloo::ResultIterator iter = query.exec();
+    std::vector<std::string> results;
+    while (iter.next()) {
+        const QString filePath = iter.filePath();
+        results.push_back(filePath.toStdString());
+    }
+    return results;
+}

--- a/src/file_search/file_search.hpp
+++ b/src/file_search/file_search.hpp
@@ -1,3 +1,3 @@
 #include <string>
 #include <vector>
-std::vector<std::string> fileSearchKDE(const std::string& searchTerm);
+std::vector<std::string> fileSearchKDE(const std::string &searchTerm);

--- a/src/file_search/file_search.hpp
+++ b/src/file_search/file_search.hpp
@@ -1,0 +1,2 @@
+//https://invent.kde.org/frameworks/baloo/-/blob/master/src/tools/baloosearch
+Baloo::Query query;

--- a/src/file_search/file_search.hpp
+++ b/src/file_search/file_search.hpp
@@ -1,2 +1,3 @@
-//https://invent.kde.org/frameworks/baloo/-/blob/master/src/tools/baloosearch
-Baloo::Query query;
+#include <string>
+#include <vector>
+std::vector<std::string> fileSearchKDE(const std::string& searchTerm);

--- a/src/model_backend/thirdparty/CMakeLists.txt
+++ b/src/model_backend/thirdparty/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(CMAKE_AUTOMOC OFF)
 set(CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
 set(BUILD_SHARED_LIBS OFF)
 #set(WHISPER_OPENVINO ON)

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(KF6 REQUIRED COMPONENTS
     CoreAddons
     QQC2DesktopStyle
     IconThemes
+    Baloo 
     )
 
 #these two options MUST be here only, else qt like a big dumb pussy will not allow us to compile this and throw random errors
@@ -60,6 +61,7 @@ target_link_libraries(koolintelligence
     KF6::I18n
     KF6::CoreAddons
     KF6::IconThemes
+    KF6::Baloo
 )
     
 install(TARGETS koolintelligence ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -10,6 +10,7 @@
 
 #include "app.hpp"
 #include "logging.hpp"
+#include "file_search.hpp"
 
 template<typename T>
 inline void registerInstance(T *instance, const char *name)
@@ -50,6 +51,10 @@ App::App(int argc, char *argv[])
 int App::run()
 {
     // LOG_INFO("app", this->model_api_instance->transcriptionService());
+    // std::vector<std::string> results = fileSearchKDE("main.cpp");
+    // for (const std::string &result : results) {
+    //     LOG_INFO("App", "File Search Result: " + result);
+    // }
     if (this->engine->rootObjects().isEmpty()) {
         return -1;
     }

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -9,8 +9,8 @@
 #include <unistd.h>
 
 #include "app.hpp"
-#include "logging.hpp"
 #include "file_search.hpp"
+#include "logging.hpp"
 
 template<typename T>
 inline void registerInstance(T *instance, const char *name)


### PR DESCRIPTION
It will only return file paths for now. 
However the results are also based on the file contents as indexed by baloo/krunner. 
Note that this is KDE specific.

Also, there is fix for CMake warning. No cmake warnings should come now.

Checklist(to mark the completed tasks, replace the space inside the brackets with an x):
- [x] Are the variable and function named correctly. Example: ```myNewVariable```
- [x] Are the class and structs named correctly. Example: ```MyNewClass```
- [x] Are the comments clear and concise.
- [x] Is the documentation updated.
- [x] There are no new warnings than before*.
- [x] Are the logs used correctly. Only logs are allowed. No print statements.

*The only reason new warnings may be allowed is if the code that produces the warnings are from third party code that we cannot modify.(Example: Qt, KDE Frameworks, git submodules etc.)
