### PR TITLE
ability to reset chat + markdown support so code output looks better

### DIFF
--- a/src/model_backend/model_api.cpp
+++ b/src/model_backend/model_api.cpp
@@ -264,3 +264,8 @@ std::string ModelApi::transcriptionService(std::vector<std::string> args)
     LOG_INFO("ModelApi", transcript);
     return transcript;
 }
+
+void ModelApi::resetCurSessionHistory()
+{
+    this->curSessionHistory.clear();
+}

--- a/src/model_backend/model_api.hpp
+++ b/src/model_backend/model_api.hpp
@@ -77,4 +77,5 @@ public:
     std::string generationWithImage(const std::string &prompt, const std::string &imagePath);
 
     std::string transcriptionService(std::vector<std::string> argv = std::vector<std::string>());
+    void resetCurSessionHistory();
 };

--- a/src/ui/app.cpp
+++ b/src/ui/app.cpp
@@ -125,3 +125,9 @@ App::~App()
     delete this->model_api_instance;
     delete this->userPromptField;
 }
+
+void App::resetChat()
+{
+    this->chatHistoryModel->clearChatHistory();
+    this->model_api_instance->resetCurSessionHistory();
+}

--- a/src/ui/app.hpp
+++ b/src/ui/app.hpp
@@ -12,6 +12,7 @@ public:
     App(int argc, char *argv[]);
     int run();
     void userPrompt(const QString &text);
+    void resetChat();
     ~App();
 
 private:

--- a/src/ui/chatHistoryModel.cpp
+++ b/src/ui/chatHistoryModel.cpp
@@ -47,3 +47,10 @@ void ChatHistoryModel::removeChatMessage(int index)
     m_chatHistory.remove(index);
     endRemoveRows();
 }
+
+void ChatHistoryModel::clearChatHistory()
+{
+    beginResetModel();
+    m_chatHistory.clear();
+    endResetModel();
+}

--- a/src/ui/chatHistoryModel.hpp
+++ b/src/ui/chatHistoryModel.hpp
@@ -32,6 +32,8 @@ public:
 
     void removeChatMessage(int index);
 
+    void clearChatHistory();
+
 private:
     QVector<ChatMessage> m_chatHistory;
 };

--- a/src/ui/qml/ChatHistory.qml
+++ b/src/ui/qml/ChatHistory.qml
@@ -21,7 +21,7 @@ Controls.ScrollView {
     Component {
         id: chatHistoryDelegate
         Kirigami.AbstractCard {
-            width: parent?.width - anchors.margins
+            width: Math.max(0, parent.width - anchors.margins)
             anchors.right: alignLeft ? undefined : parent?.right
             anchors.left: alignLeft ? parent?.left : undefined
             anchors.margins: 90
@@ -45,14 +45,8 @@ Controls.ScrollView {
                 level: 3
                 wrapMode: Text.WordWrap
                 Layout.alignment: alignLeft ? Qt.AlignLeft : Qt.AlignRight
+                textFormat: Text.MarkdownText
                 }
-                // Controls.MarkdownText {
-                // Layout.fillWidth: true
-                // text: chatText
-                // level: 3
-                // wrapMode: Text.WordWrap
-                // Layout.alignment: alignLeft ? Qt.AlignLeft : Qt.AlignRight
-                // }
                 Kirigami.Heading {
                 text: time
                 level: 9

--- a/src/ui/qml/Main.qml
+++ b/src/ui/qml/Main.qml
@@ -42,6 +42,13 @@ Kirigami.ApplicationWindow {
                     terminalLayout.visible = !terminalLayout.visible
                     terminalSeperator.visible = !terminalSeperator.visible
                 }
+            },
+            Kirigami.Action{
+                text: i18n("Reset Chat")
+                icon.name: "edit-clear-symbolic"
+                onTriggered: {
+                    UserPromptField.resetChat()
+                }
             }
         ]
         spacing: 0

--- a/src/ui/userPromptField.cpp
+++ b/src/ui/userPromptField.cpp
@@ -12,3 +12,8 @@ void UserPromptField::setApp(void *app)
 {
     this->app = app;
 }
+
+void UserPromptField::resetChat()
+{
+    ((App *)this->app)->resetChat();
+}

--- a/src/ui/userPromptField.hpp
+++ b/src/ui/userPromptField.hpp
@@ -9,6 +9,8 @@ public:
     {
     }
     Q_SLOT void handleTextChange(const QString &text);
+
+    Q_SLOT void resetChat();
     void setApp(void *app);
 
 private:


### PR DESCRIPTION
ability to reset chat + markdown support so code output looks better

Checklist(to mark the completed tasks, replace the space inside the brackets with an x):
- [x] Are the variable and function named correctly. Example: ```myNewVariable```
- [x] Are the class and structs named correctly. Example: ```MyNewClass```
- [x] Are the comments clear and concise.
- [x] Is the documentation updated.
- [x] There are no new warnings than before*.
- [x] Are the logs used correctly. Only logs are allowed. No print statements.

*The only reason new warnings may be allowed is if the code that produces the warnings are from third party code that we cannot modify.(Example: Qt, KDE Frameworks, git submodules etc.)
